### PR TITLE
Updated argon2kt version to fix 16kb page size issue

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,7 +19,7 @@ android {
     buildToolsVersion safeExtGet('buildToolsVersion', '30.0.3')
 
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 16)
+        minSdkVersion safeExtGet('minSdkVersion', 21)
         targetSdkVersion safeExtGet('targetSdkVersion', 30)
         versionCode 1
         versionName '1.0'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,5 +33,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.lambdapioneer.argon2kt:argon2kt:1.3.0'
+    implementation 'com.lambdapioneer.argon2kt:argon2kt:1.6.0'
 }


### PR DESCRIPTION
Google now requries 16kb page sizes for android applications. The version of `argon2kt` used in this package does not support this, however version [v1.6.0](https://github.com/lambdapioneer/argon2kt/releases/tag/v1.6.0) does. 

Also had to bump the minSdk version to 21 to match `argon2kt`

Shouldn't be any API changes, and my testing doesn't show any problems, but the maintainers would like me to do some more rigorous testing I can.