### PR TITLE
Android: Replace jcenter() with mavenCentral() for Gradle 9 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ android {
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
### Summary
Replaces `jcenter()` with `mavenCentral()` in `android/build.gradle` so the library builds with `Gradle 9.x`.

### Context
- JCenter (JFrog’s repo) was made read-only in March 2021 and fully shut down on August 15, 2024; traffic is now redirected to Maven Central.
- Gradle deprecated jcenter() in Gradle 7 and removed it in Gradle 9.0. Builds that still reference jcenter() fail on Gradle 9 with an error that the API no longer exists.
- Maven Central is the standard, long-lived repo for JVM/Android artifacts and is the recommended replacement.
- React Native’s newer versions and tooling assume Gradle 9–compatible Android builds; upgrading React Native (and its Android Gradle Plugin / Gradle wrapper) typically requires all native modules to drop jcenter() in favor of mavenCentral(). This change is needed so the library works in apps that have upgraded React Native and Gradle.
### Change
In the repositories block of android/build.gradle, `jcenter()` is replaced with `mavenCentral()`.
### Compatibility
Backwards compatible: mavenCentral() is supported in all recent Gradle versions (6.x, 7.x, 8.x, 9.x), so existing projects on older Gradle are unaffected.
Dependencies used by this module (com.facebook.react:react-native, com.lambdapioneer.argon2kt:argon2kt) are available from Maven Central.